### PR TITLE
update all statuses on todos

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,4 @@
 exclude_patterns:
-  - 'node_modules'
-  - 'src/__tests__'
+  - "node_modules"
+  - "src/__tests__"
+  - "src/routes"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ An app that helps you to keep track of your day-to-day tasks.
 - **POST /api/auth/signup:** Create an account
 - **POST /api/auth/login:** Log into your account
 - **POST /api/todos/:** Create a new task
+- **DELETE /api/todos/:** Delete all tasks
 - **GET /todos/:todoId:** Get a single task
 - **GET /api/todos:** Get all tasks
 - **GET /api/todos?s='search_query':** Search through tasks
 - **GET /api/todos?exp:** Download tasks to a csv file
+- **PATCH /todos/completed** Update all tasks' completed statuses
 - **PATCH /todos/:todoId:** Update a task
 - **DELETE /todos/:todoId:** Delete a task
 - **GET /api/logs/:key:** Download logs

--- a/src/__tests__/todos.test.js
+++ b/src/__tests__/todos.test.js
@@ -68,6 +68,12 @@ describe('Todos tests', () => {
       .send({ ...mockData.todo, title: 'Updated title' });
     expect(res.status).to.eql(200);
   });
+  it('should update all todo completed statuses', async () => {
+    const res = await request.patch('/api/todos/completed')
+      .set('Authorization', `Bearer ${mockData.tokenTwo}`)
+      .send({ completed: true });
+    expect(res.status).to.eql(200);
+  });
   it('should not update todo with wrong info', async () => {
     const res = await request.patch(`/api/todos/${mockData.todoId2}`)
       .set('Authorization', `Bearer ${mockData.tokenTwo}`)

--- a/src/controllers/todos.js
+++ b/src/controllers/todos.js
@@ -61,15 +61,33 @@ export default class TodosController {
    * @returns {object} Updated todo
    */
   static async updateTodo(req, res) {
-    const { title, description, priority } = req.body;
+    const {
+      title, description, priority, completed,
+    } = req.body;
     const { __todo: todo } = req;
     const updatedTodo = await DBService.dbAction(todo, 'update', {
       title,
       description,
       priority,
+      completed,
       modifiedAt: new Date().toLocaleString(),
     });
     return Response.success(res, 200, 'Todo updated.', updatedTodo);
+  }
+
+  /** Update a todo (async)
+   *
+   * @param {object} req request
+   * @param {object} res response
+   * @returns {object} Updated todo
+   */
+  static async updateAllCompleted(req, res) {
+    const { completed } = req.body;
+    await DBService.dbAction(Todo, 'update', {
+      completed,
+      modifiedAt: new Date().toLocaleString(),
+    }, { where: { todoistId: req.user.id } });
+    return Response.success(res, 200, 'All Todos/Tasks statuses updated.');
   }
 
   /** Delete a todo (async)

--- a/src/database/models/Todo.js
+++ b/src/database/models/Todo.js
@@ -24,6 +24,11 @@ const Todo = db.define(
       },
       allowNull: false,
     },
+    completed: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
   },
   { timestamps: true, updatedAt: 'modifiedAt' },
 );

--- a/src/routes/docs/swagger.json
+++ b/src/routes/docs/swagger.json
@@ -114,10 +114,10 @@
             "required": false
           },
           {
-            "name":"exp",
-            "in":"query",
-            "type":"string",
-            "description":"Export prompt (optional). Set it to 'yes' for exporting todos/tasks ",
+            "name": "exp",
+            "in": "query",
+            "type": "string",
+            "description": "Export prompt (optional). Set it to 'yes' for exporting todos/tasks ",
             "required": false
           }
         ],
@@ -160,7 +160,7 @@
           }
         }
       },
-      "delete":{
+      "delete": {
         "security": [
           {
             "bearerAuth": []
@@ -174,6 +174,45 @@
         "responses": {
           "200": {
             "description": "All Todos deleted"
+          },
+          "401": {
+            "description": "Unauthenticated"
+          }
+        }
+      }
+    },
+    "/api/todos/completed": {
+      "patch": {
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "tags": [
+          "Todos"
+        ],
+        "summary": "Update all todo/task completed statuses",
+        "description": "Update all todo/task completed statuses",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "completed": {
+                    "type": "string",
+                    "description": "completed status (true or false)",
+                    "example": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "All Todos/Tasks statuses updated"
           },
           "401": {
             "description": "Unauthenticated"

--- a/src/routes/todos.js
+++ b/src/routes/todos.js
@@ -8,7 +8,8 @@ const router = Router();
 
 router.get('/',
   async(Auth.authenticate),
-  (req, res, next) => Checker.validate(res, req.query?.s, 'todoSearch', next),
+  (req, res, next) => Checker.validate(res, req.query.s, 'todoSearch', next),
+  (req, res, next) => Checker.validate(res, req.query.exp, 'exp', next),
   async(TodosController.getTodos));
 
 router.post('/',
@@ -19,6 +20,11 @@ router.post('/',
 router.delete('/',
   async(Auth.authenticate),
   async(TodosController.deleteTodos));
+
+router.patch('/completed',
+  async(Auth.authenticate),
+  (req, res, next) => Checker.validate(res, req.body, 'todoUpdate', next),
+  async(TodosController.updateAllCompleted));
 
 router.get('/:todoId',
   async(Auth.authenticate),

--- a/src/services/db.js
+++ b/src/services/db.js
@@ -10,8 +10,8 @@ export default class DBService {
  * @param {object} data data or conditions
  * @returns {object} result
  */
-  static async dbAction(model, action, data) {
-    const result = await model[action](data);
+  static async dbAction(model, action, data, extra) {
+    const result = await model[action](data, extra);
     return result;
   }
 

--- a/src/services/schema.js
+++ b/src/services/schema.js
@@ -46,6 +46,9 @@ const schema = {
     priority: Joi.string()
       .valid('HIGH', 'MEDIUM', 'LOW')
       .error(new Error('priority must be one of HIGH, MEDIUM or LOW')),
+    completed: Joi.boolean()
+      .valid(true, false)
+      .error(new Error('completed must be true or false')),
   }),
   todoId: Joi
     .number()
@@ -57,6 +60,9 @@ const schema = {
     .trim()
     .max(100)
     .error(new Error('Invalid Search Parameter')),
+  exp: Joi.string()
+    .valid('yes')
+    .error(new Error('exp parameter can only be \'yes\'')),
 };
 
 export default schema;


### PR DESCRIPTION
#### What does this PR do?

Add PATCH  route at '/api/todos/completed' for updating completed statuses of all todos

#### Description of Task to be completed?

- add completed field on a todo
- add patch endpoint to update all completed statuses at once
- write test for the feature
- write docs for the feature

#### How should this be manually tested?

- clone the repo
- run the app (normally or with docker - instructions to run in the Readme)
- test the endpoint with your favorite api client or go to '/api/docs'

#### Any background context you want to provide?
N/A

#### What are the relevant stories?
N/A

#### Screenshots
![image](https://user-images.githubusercontent.com/53472419/109521311-d8ce4c80-7ab5-11eb-8bb5-d19c4bddb20f.png)


